### PR TITLE
Replace stringly typed macro implmentation

### DIFF
--- a/Sources/CreateAsyncStreamMacros/CreateAsyncStreamMacro.swift
+++ b/Sources/CreateAsyncStreamMacros/CreateAsyncStreamMacro.swift
@@ -21,32 +21,50 @@ public struct CreateAsyncStreamMacro: MemberMacro {
   public static func expansion(of node: AttributeSyntax,
                                providingMembersOf declaration: some DeclGroupSyntax,
                                in context: some MacroExpansionContext) throws -> [DeclSyntax] {
-    guard let arguments = Syntax(node.argument)?.children(viewMode: .sourceAccurate),
-          let typeArgument = arguments.first,
-          let nameArgument = arguments.dropFirst().first
-    else {
-      fatalError("who knows what happened")
+    guard declaration.is(ClassDeclSyntax.self) else {
+      throw Error.canOnlyBeAppliedToClass
     }
-    let type = typeArgument.description
-      .replacingOccurrences(of: "of:", with: "")
-      .replacingOccurrences(of: ",", with: "")
-      .trimmingCharacters(in: .whitespacesAndNewlines)
-    let t = type.replacingOccurrences(of: ".self", with: "")
-    let name = nameArgument.description
-      .replacingOccurrences(of: "named:", with: "")
-      .replacingOccurrences(of: "\"", with: "")
-      .trimmingCharacters(in: .whitespacesAndNewlines)
+    guard case .argumentList(let argumentList) = node.argument else {
+      fatalError("Macro attribute has no arguments. Macro declaration must be wrong.")
+    }
+    guard let typeArgument = argumentList.first(where: { $0.label?.text == "of" }),
+          let nameArgument = argumentList.first(where: { $0.label?.text == "named" })
+    else {
+      fatalError("Macro attribute doesn't have expected arguments. Macro declaration must be wrong.")
+    }
+    let type = typeArgument.expression
+    guard let typeWithSelf = type.as(MemberAccessExprSyntax.self),
+          typeWithSelf.name.text == "self",
+          let t = typeWithSelf.base
+    else {
+      throw Error.typeDoesntEndWithDotSelf
+    }
+    guard let nameLiteral = nameArgument.expression.as(StringLiteralExprSyntax.self),
+          let name = nameLiteral.representedLiteralValue
+    else {
+      throw Error.nameMustBeALiteral
+    }
 
     return [
       "public var \(raw: name): AsyncStream<\(raw: t)> { _\(raw: name)}",
       "private let (_\(raw: name), \(raw: name)Continuation) = AsyncStream.makeStream(of: \(raw: type))"
     ]
   }
-  
-  
-
 }
 
+enum Error: Swift.Error, CustomStringConvertible {
+  case canOnlyBeAppliedToClass
+  case typeDoesntEndWithDotSelf
+  case nameMustBeALiteral
+
+  var description: String {
+    switch self {
+    case .canOnlyBeAppliedToClass: "Macro can only be applied to a class"
+    case .typeDoesntEndWithDotSelf: "Cannot parse argument 'of'. Must be a type, ending in '.self'"
+    case .nameMustBeALiteral: "Argument 'named' must be a string literal"
+    }
+  }
+}
 
 @main
 struct CreateAsyncStreamPlugin: CompilerPlugin {

--- a/Tests/CreateAsyncStreamTests/CreateAsyncStreamTests.swift
+++ b/Tests/CreateAsyncStreamTests/CreateAsyncStreamTests.swift
@@ -4,22 +4,83 @@ import XCTest
 import CreateAsyncStreamMacros
 
 let testMacros: [String: Macro.Type] = [
-    "createAsyncStream": CreateAsyncStreamMacro.self,
+  "CreateAsyncStream": CreateAsyncStreamMacro.self,
 ]
 
 final class CreateAsyncStreamTests: XCTestCase {
-    func testMacro() {
-        assertMacroExpansion(
-            """
-            @CreateAsyncStream(of: Int.self, named: "numbers")
-            """,
-            expandedSource: """
-            public var numbers: AsyncStream<Int> { _numbers }
-            private let (_numbers, numbersContinuation) = AsyncStream.makeStream(of: Int.self)
-            """,
-            macros: testMacros
-        )
-    }
+  func testMacro() {
+    assertMacroExpansion(
+      """
+      @CreateAsyncStream(of: Int.self, named: "numbers")
+      class MyClass {
+      }
+      """,
+      expandedSource: """
+      class MyClass {
+          public var numbers: AsyncStream<Int> {
+              _numbers
+          }
+          private let (_numbers, numbersContinuation) = AsyncStream.makeStream(of: Int.self)
+      }
+      """,
+      macros: testMacros
+    )
+  }
 
+  func testWithStruct() {
+    assertMacroExpansion(
+      """
+      @CreateAsyncStream(of: Int.self, named: "numbers")
+      struct MyStruct {
+      }
+      """,
+      expandedSource: """
+      struct MyStruct {
+      }
+      """,
+      diagnostics: [
+        DiagnosticSpec(message: "Macro can only be applied to a class", line: 1, column: 1)
+      ],
+      macros: testMacros
+    )
+  }
+
+  func testWithNonLiteralStringArgument() {
+    assertMacroExpansion(
+      """
+      @CreateAsyncStream(of: Int.self, named: "num" + "bers")
+      class MyStruct {
+      }
+      """,
+      expandedSource: """
+      class MyStruct {
+      }
+      """,
+      diagnostics: [
+        DiagnosticSpec(message: "Argument 'named' must be a string literal", line: 1, column: 1)
+      ],
+      macros: testMacros
+    )
+  }
+
+  func testWithNonLiteralTypeArgument() {
+    assertMacroExpansion(
+      """
+      let int = Int.self
+      @CreateAsyncStream(of: int, named: "numbers")
+      class MyStruct {
+      }
+      """,
+      expandedSource: """
+      let int = Int.self
+      class MyStruct {
+      }
+      """,
+      diagnostics: [
+        DiagnosticSpec(message: "Cannot parse argument 'of'. Must be a type, ending in '.self'", line: 2, column: 1)
+      ],
+      macros: testMacros
+    )
+  }
 
 }


### PR DESCRIPTION
Here are some suggestions how to make use of the actual SwiftSyntax tree in the macro implementation. I also added some tests for the error cases I implemented. (The diagnostics could be improved further by attaching them to the correct syntax node so that the compiler reports them with the correct line numbers).